### PR TITLE
Remove common Micro.blog elements from head and use new partial instead

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -10,44 +10,13 @@
   {{- partial "seo_tags.html" . -}}
   <meta name="referrer" content="no-referrer-when-downgrade" />
 
-  {{ with .OutputFormats.Get "rss" -}}
-  {{ printf `<link rel="%s" type="%s" href="%s" title="%s" />` .Rel .MediaType.Type .Permalink $.Site.Title | safeHTML }}
-  {{ end -}}
-
-
-  <link rel="stylesheet" href="{{ "custom.css" | relURL }}">
-  <link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
-	{{ with .Site.Params.twitter_username }}
-		<link rel="me" href="https://twitter.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.github_username }}
-		<link rel="me" href="https://github.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.instagram_username }}
-		<link rel="me" href="https://instagram.com/{{ . }}" />
-	{{ end }}
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-	<link rel="micropub" href="https://micro.blog/micropub" />
-	<link rel="microsub" href="https://micro.blog/microsub" />
-	<link rel="webmention" href="https://micro.blog/webmention" />
-	<link rel="subscribe" href="https://micro.blog/users/follow" />
-	<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-
-  {{ range .Site.Params.plugins_css }}
-    <link rel="stylesheet" href="{{ . }}" />
-  {{ end }}
-  {{ range $filename := .Site.Params.plugins_html }}
-    {{ partial $filename $ }}
-  {{ end }}
-
-
   {{- partial "style.html" . -}}
 
   <!-- A partial to be overwritten by the user.
   Simply place a custom_head.html into
   your local /layouts/partials-directory -->
   {{- partial "custom_head.html" . -}}
+  {{ partial "microblog_head.html" . }}
 </head>
 
 <body>


### PR DESCRIPTION
Here's Bear updated to use the Micro.blog common head partial. All tests pass, and the test blog looks okay when built locally.